### PR TITLE
Use Mutex for runtime and client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.24", features = ["rt", "fs"] }
 reqwest = { version = "0.11.14", features = ["stream"] }
 futures = "0.3.26"
 bytes = "1.4.0"
+parking_lot = "0.12.1"
 
 [profile.release]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@ fn cat_ranges<'a>(
     let mut result: Vec<Bytes> = Vec::with_capacity(urls.len());
     let headers: HashMap<&str, String> = headers.unwrap_or(HashMap::new());
     let method = method.unwrap_or("GET");
-    println!("{}", method);
     let method = reqwest::Method::from_str(method).unwrap();
     let coroutine = async {
         match (starts, ends) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,6 @@ fn get<'a>(
     py: Python<'a>, urls: Vec<&str>, lpaths: Vec<&str>,
     headers: Option<HashMap<&str, String>>, method: Option<&str>,
 ) -> () {
-    ensure_client();
-    ensure_runtime();
     let headers: HashMap<&str, String> = headers.unwrap_or(HashMap::new());
     let method = method.unwrap_or("GET");
     let method = reqwest::Method::from_str(method).unwrap();
@@ -134,8 +132,6 @@ fn cat_ranges<'a>(
     ends: Option<Vec<usize>>, headers: Option<HashMap<&str, String>>,
     method: Option<&str>,
 ) -> &'a PyTuple {
-    ensure_client();
-    ensure_runtime();
     let mut result: Vec<Bytes> = Vec::with_capacity(urls.len());
     let headers: HashMap<&str, String> = headers.unwrap_or(HashMap::new());
     let method = method.unwrap_or("GET");
@@ -176,5 +172,7 @@ fn cat_ranges<'a>(
 fn rfsspec(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cat_ranges, m)?)?;
     m.add_function(wrap_pyfunction!(get, m)?)?;
+    ensure_client();
+    ensure_runtime();
     Ok(())
 }


### PR DESCRIPTION
Take it or leave it, this ought to fix [thread local issues](https://github.com/martindurant/rfsspec/actions/runs/4186929644/jobs/7256093722).

I didn't look too much into the change in the `examples/script.py` timing, but this doesn't have any discernible decrease in performance, but do note that even on `main` branch, the timings seem out of date from what's on README.  